### PR TITLE
Enabled running swagger-ui without OAuth integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build/
 
 node_modules/
 dist/
+www/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 
 language: node_js
 node_js:
-  - '0.10'
   - '0.12'
 
 addons:

--- a/swagger-ui/Dockerfile
+++ b/swagger-ui/Dockerfile
@@ -4,10 +4,7 @@ FROM registry.opensource.zalan.do/stups/node:0.12-20
 ADD /scm-source.json /scm-source.json
 
 # copy resources
-COPY ./dist/ /www/dist/
-COPY ./dist/index.html /www/
-COPY ./server/server.js /www/
-COPY ./server/package.json /www/
+COPY ./www/ /www/
 
 # install dependencies
 

--- a/swagger-ui/README.md
+++ b/swagger-ui/README.md
@@ -16,7 +16,7 @@ docker build -t swagger-ui:1.0-SNAPSHOT .
 Now, you can start the docker image and access the frontend <http://localhost:8080>.
 
 ```
-docker run -it -p 8080:8080 swagger-ui:1.0-SNAPSHOT
+docker run -it -p 8080:8080 -e SUIENV_STORAGE_BASE_URL=${storage_base_url} swagger-ui:1.0-SNAPSHOT
 ```
 
 ### Run with OAuth 2.0

--- a/swagger-ui/README.md
+++ b/swagger-ui/README.md
@@ -1,6 +1,7 @@
 # Swagger UI
 
-This is Swagger UI application. It is currently used to browse the API definitions. It relies on the API definitions which are persisted in the Storage service.
+This is Swagger UI application. It is currently used to browse all crawled API definitions.
+It relies on the API definitions which are persisted in the [storage](../storage) service.
 
 
 ## Build and run locally
@@ -21,9 +22,8 @@ gulp serve
 
 or, with OAuth integration:
 
-
 ```
 gulp serve serve-with-oauth
 ```
 
-Now, you cann access the frontend <http://localhost:8080>.
+Now, you can access the frontend <http://localhost:8080>.

--- a/swagger-ui/README.md
+++ b/swagger-ui/README.md
@@ -5,29 +5,25 @@ This is Swagger UI application. It is currently used to browse the API definitio
 
 ## Build and run locally
 
-In order to start the application locally (e.g. testing or development purposes) you should build the sources:
+In order to start the application locally (e.g. for testing or development purposes) you should build and bundle the sources first:
 
 ```
+cd server && npm install
 gulp
 ```
 
-and build the docker image:
+then, you can start the server locally without OAuth integration:
 
 
 ```
-docker build -t swagger-ui:1.0-SNAPSHOT .
+gulp serve
 ```
 
-### Run without OAuth 2.0
-Now, you can start the docker image and access the frontend <http://localhost:8080>.
+or, with OAuth integration:
+
 
 ```
-docker run -it -p 8080:8080 -e SUIENV_STORAGE_BASE_URL=${storage_base_url} swagger-ui:1.0-SNAPSHOT
+gulp serve serve-with-oauth
 ```
 
-### Run with OAuth 2.0
-If you want to test the application with OAuth2.0 security, use `test-docker.sh` script instead:
-
-```
-./test-docker.sh swagger-ui:1.0-SNAPSHOT
-```
+Now, you cann access the frontend <http://localhost:8080>.

--- a/swagger-ui/README.md
+++ b/swagger-ui/README.md
@@ -5,7 +5,13 @@ This is Swagger UI application. It is currently used to browse the API definitio
 
 ## Build and run locally
 
-In order to start the application locally (e.g. testing or development purposes) you should build the docker image first:
+In order to start the application locally (e.g. testing or development purposes) you should build the sources:
+
+```
+gulp
+```
+
+and build the docker image:
 
 
 ```

--- a/swagger-ui/README.md
+++ b/swagger-ui/README.md
@@ -1,0 +1,27 @@
+# Swagger UI
+
+This is Swagger UI application. It is currently used to browse the API definitions. It relies on the API definitions which are persisted in the Storage service.
+
+
+## Build and run locally
+
+In order to start the application locally (e.g. testing or development purposes) you should build the docker image first:
+
+
+```
+docker build -t swagger-ui:1.0-SNAPSHOT .
+```
+
+### Run without OAuth 2.0
+Now, you can start the docker image and access the frontend <http://localhost:8080>.
+
+```
+docker run -it -p 8080:8080 swagger-ui:1.0-SNAPSHOT
+```
+
+### Run with OAuth 2.0
+If you want to test the application with OAuth2.0 security, use `test-docker.sh` script instead:
+
+```
+./test-docker.sh swagger-ui:1.0-SNAPSHOT
+```

--- a/swagger-ui/gulpfile.js
+++ b/swagger-ui/gulpfile.js
@@ -41,7 +41,7 @@ gulp.task('clean', function() {
 /**
  * Starts node server
  */
-gulp.task('server', function() {
+gulp.task('server', ['set-env-vars'], function() {
   if (node) node.kill()
   node = spawn('node', ['server.js'], {stdio: 'inherit', cwd: 'www'})
   node.on('close', function (code) {
@@ -50,6 +50,26 @@ gulp.task('server', function() {
     }
   });
 })
+
+/**
+ * Sets default env variables
+ */
+gulp.task('set-env-vars', function() {
+  process.env.SUIENV_STORAGE_BASE_URL = 'http://localhost:8010';
+  return;
+});
+
+/**
+ * Sets OAuth environment variables
+ */
+gulp.task('set-oauth-env-vars', function() {
+  process.env.SUIENV_OAUTH_AUTH_URL = 'http://localhost:5002/auth';
+  process.env.SUIENV_OAUTH_CLIENT_ID = 'swagger';
+  process.env.SUIENV_OAUTH_REALM = 'realm';
+  process.env.SUIENV_OAUTH_REDIRECT_URL = 'http://localhost:8080';
+  process.env.SUIENV_OAUTH_SCOPES = 'uid';
+  return;
+});
 
 /**
  * Processes Handlebars templates
@@ -183,3 +203,4 @@ function log(error) {
 
 gulp.task('default', ['dist', 'copy']);
 gulp.task('serve', ['watch', 'server']);
+gulp.task('serve-with-oauth', ['set-oauth-env-vars', 'watch', 'server']);

--- a/swagger-ui/test-docker.sh
+++ b/swagger-ui/test-docker.sh
@@ -8,4 +8,4 @@ docker run \
     -e SUIENV_OAUTH_REDIRECT_URL=http://192.168.59.103:8080 \
     -e SUIENV_OAUTH_SCOPES=uid \
     -u 998 \
-    image
+    $1


### PR DESCRIPTION
#24 Improving frontend development workflow: 
* Adding readme file including how-to start swagger-ui locally with and without oauth2.