### PR TITLE
Add metrics to storage

### DIFF
--- a/storage/Dockerfile
+++ b/storage/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-42
+FROM registry.opensource.zalan.do/stups/openjdk:8-52
 
 MAINTAINER Zalando SE
 

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     compile('joda-time:joda-time:2.9.7')
     compile('org.jadira.usertype:usertype.core:5.0.0.GA')
     compile('com.fasterxml.jackson.datatype:jackson-datatype-joda:2.8.6')
+    compile("org.zalando.zmon:zmon-actuator:0.9.7")
+    compile("io.dropwizard.metrics:metrics-core:3.1.0")
     testCompile('org.springframework.boot:spring-boot-starter-test')
     testCompile('org.assertj:assertj-core:3.6.1')
     testCompile('org.apache.commons:commons-lang3:3.5')

--- a/storage/load-test-data.sh
+++ b/storage/load-test-data.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-base_url=${1:-localhost:8010}
+base_url=${1:-localhost:8080}
 storage_project_path=${2:-.}
 
 curl -H "Content-Type: application/json" -X PUT --data @${storage_project_path}/src/test/resources/petstore-full.json ${base_url}/apps/petstore

--- a/storage/load-test-data.sh
+++ b/storage/load-test-data.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-base_url=${1:-localhost:8080}
+base_url=${1:-localhost:8010}
 storage_project_path=${2:-.}
 
 curl -H "Content-Type: application/json" -X PUT --data @${storage_project_path}/src/test/resources/petstore-full.json ${base_url}/apps/petstore

--- a/storage/src/main/java/org/zalando/apidiscovery/storage/ApiDefinitionRepository.java
+++ b/storage/src/main/java/org/zalando/apidiscovery/storage/ApiDefinitionRepository.java
@@ -18,4 +18,10 @@ interface ApiDefinitionRepository extends CrudRepository<ApiDefinition, String> 
     List<ApiDefinition> findNotUpdatedSinceAndInactive(DateTime olderThan);
 
     List<ApiDefinition> findByLifecycleState(String lifecycleState);
+
+    @Query("select new org.zalando.apidiscovery.storage.ApiDefinitionStatusStatistics(a.status, count(a)) from ApiDefinition a group by a.status")
+    List<ApiDefinitionStatusStatistics> countStatus();
+
+    @Query("select new org.zalando.apidiscovery.storage.ApiDefinitionStatusStatistics(a.lifecycleState, count(a)) from ApiDefinition a group by a.lifecycleState")
+    List<ApiDefinitionStatusStatistics> countLifecycleStates();
 }

--- a/storage/src/main/java/org/zalando/apidiscovery/storage/ApiDefinitionStatusStatistics.java
+++ b/storage/src/main/java/org/zalando/apidiscovery/storage/ApiDefinitionStatusStatistics.java
@@ -1,0 +1,38 @@
+package org.zalando.apidiscovery.storage;
+
+final class ApiDefinitionStatusStatistics {
+
+    private final String status;
+    private final Long count;
+
+    public ApiDefinitionStatusStatistics(String status, Long count) {
+        this.status = status;
+        this.count = count;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Long getCount() {
+        return count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ApiDefinitionStatusStatistics that = (ApiDefinitionStatusStatistics) o;
+
+        if (!status.equals(that.status)) return false;
+        return count.equals(that.count);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = status.hashCode();
+        result = 31 * result + count.hashCode();
+        return result;
+    }
+}

--- a/storage/src/main/java/org/zalando/apidiscovery/storage/MetricsCollector.java
+++ b/storage/src/main/java/org/zalando/apidiscovery/storage/MetricsCollector.java
@@ -17,7 +17,7 @@ public class MetricsCollector {
         this.repository = repository;
     }
 
-    @Scheduled(fixedDelay = 1000L)
+    @Scheduled(fixedDelayString = "${metrics-collecting.delay}")
     public void collectMetrics() {
         repository.countStatus().forEach(c ->
                 metricServices.submit("gauge.apis.crawled." + c.getStatus().toLowerCase(), c.getCount()));

--- a/storage/src/main/java/org/zalando/apidiscovery/storage/MetricsCollector.java
+++ b/storage/src/main/java/org/zalando/apidiscovery/storage/MetricsCollector.java
@@ -1,0 +1,27 @@
+package org.zalando.apidiscovery.storage;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.dropwizard.DropwizardMetricServices;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetricsCollector {
+
+    private final DropwizardMetricServices metricServices;
+    private final ApiDefinitionRepository repository;
+
+    @Autowired
+    public MetricsCollector(DropwizardMetricServices metricServices, ApiDefinitionRepository repository) {
+        this.metricServices = metricServices;
+        this.repository = repository;
+    }
+
+    @Scheduled(fixedDelay = 1000L)
+    public void collectMetrics() {
+        repository.countStatus().forEach(c ->
+                metricServices.submit("gauge.apis.crawled." + c.getStatus().toLowerCase(), c.getCount()));
+        repository.countLifecycleStates().forEach(c ->
+                metricServices.submit("gauge.apis." + c.getStatus().toLowerCase(), c.getCount()));
+    }
+}

--- a/storage/src/main/java/org/zalando/apidiscovery/storage/MetricsExporter.java
+++ b/storage/src/main/java/org/zalando/apidiscovery/storage/MetricsExporter.java
@@ -1,0 +1,32 @@
+package org.zalando.apidiscovery.storage;
+
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Slf4jReporter;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetricsExporter implements ApplicationListener<ApplicationReadyEvent> {
+
+    private final MetricRegistry metricRegistry;
+
+    @Autowired
+    public MetricsExporter(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        final Slf4jReporter reporter = Slf4jReporter.forRegistry(metricRegistry)
+                .outputTo(LoggerFactory.getLogger(MetricsExporter.class))
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .build();
+        reporter.start(5, TimeUnit.SECONDS);
+    }
+}

--- a/storage/src/main/java/org/zalando/apidiscovery/storage/MetricsExporter.java
+++ b/storage/src/main/java/org/zalando/apidiscovery/storage/MetricsExporter.java
@@ -27,6 +27,6 @@ public class MetricsExporter implements ApplicationListener<ApplicationReadyEven
                 .convertRatesTo(TimeUnit.SECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .build();
-        reporter.start(5, TimeUnit.SECONDS);
+        reporter.start(5, TimeUnit.MINUTES);
     }
 }

--- a/storage/src/main/java/org/zalando/apidiscovery/storage/OAuthConfiguration.java
+++ b/storage/src/main/java/org/zalando/apidiscovery/storage/OAuthConfiguration.java
@@ -38,6 +38,7 @@ class OAuthConfiguration extends ResourceServerConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                 .antMatchers("/health").permitAll()
+                .antMatchers("/metrics").access("#oauth2.hasScope('uid')")
                 .antMatchers(HttpMethod.OPTIONS, "/apps/**").permitAll()
                 .antMatchers(HttpMethod.PUT, "/apps/**").access("#oauth2.hasScope('application.write_all')")
                 .antMatchers("/**").access("#oauth2.hasScope('uid')");

--- a/storage/src/main/resources/application-dev.yml
+++ b/storage/src/main/resources/application-dev.yml
@@ -17,6 +17,7 @@ endpoints:
     enabled: true
   metrics:
     enabled: true
+    sensitive: false
 
 security:
   basic:

--- a/storage/src/main/resources/application-dev.yml
+++ b/storage/src/main/resources/application-dev.yml
@@ -24,6 +24,7 @@ security:
     enabled: false
 
 lifecycle-check.delay: 300000
+metrics-collecting.delay: 30000
 
 inactive.time: 86400
 decommissioned.time: 172800

--- a/storage/src/main/resources/application-docker-compose.yml
+++ b/storage/src/main/resources/application-docker-compose.yml
@@ -17,6 +17,7 @@ endpoints:
     enabled: true
   metrics:
     enabled: true
+    sensitive: false
 
 security:
   basic:

--- a/storage/src/main/resources/application-docker-compose.yml
+++ b/storage/src/main/resources/application-docker-compose.yml
@@ -24,6 +24,7 @@ security:
     enabled: false
 
 lifecycle-check.delay: 300000
+metrics-collecting.delay: 30000
 
 inactive.time: 86400
 decommissioned.time: 172800

--- a/storage/src/main/resources/application.yml
+++ b/storage/src/main/resources/application.yml
@@ -29,6 +29,7 @@ security:
     enabled: false
 
 lifecycle-check.delay: 300000
+metrics-collecting.delay: 30000
 
 inactive.time: 600
 decommissioned.time: 3600

--- a/storage/src/main/resources/db/migration/V7__Add_index_to_state_column.sql
+++ b/storage/src/main/resources/db/migration/V7__Add_index_to_state_column.sql
@@ -1,0 +1,2 @@
+CREATE INDEX api_status_idx ON api(status);
+CREATE INDEX api_lifecycle_state_idx ON api(lifecycle_state);

--- a/storage/src/test/java/org/zalando/apidiscovery/storage/RestApiIntegrationTest.java
+++ b/storage/src/test/java/org/zalando/apidiscovery/storage/RestApiIntegrationTest.java
@@ -32,6 +32,9 @@ public class RestApiIntegrationTest {
     @Autowired
     private ApiDefinitionRepository repository;
 
+    @Autowired
+    private MetricsCollector metricsCollector;
+
     private ApiDefinition apiDefinition;
 
     private final TestRestTemplate restTemplate = new TestRestTemplate();
@@ -188,7 +191,7 @@ public class RestApiIntegrationTest {
     @Test
     public void retrieveMetricsAboutDifferentApiStates() throws InterruptedException {
         saveApiDefinition();
-        Thread.sleep(1500L);
+        metricsCollector.collectMetrics();
 
         ResponseEntity<JsonNode> metricsResponse = restTemplate.getForEntity("http://localhost:" + port + "/metrics", JsonNode.class);
         assertThat(metricsResponse.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/storage/src/test/java/org/zalando/apidiscovery/storage/RestApiIntegrationTest.java
+++ b/storage/src/test/java/org/zalando/apidiscovery/storage/RestApiIntegrationTest.java
@@ -1,5 +1,8 @@
 package org.zalando.apidiscovery.storage;
 
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -12,8 +15,6 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -182,6 +183,17 @@ public class RestApiIntegrationTest {
         assertThat(lastPersisted)
                 .isNotNull()
                 .isNotEqualTo(retrieveApiDefinition().getLastPersisted());
+    }
+
+    @Test
+    public void retrieveMetricsAboutDifferentApiStates() throws InterruptedException {
+        saveApiDefinition();
+        Thread.sleep(1500L);
+
+        ResponseEntity<JsonNode> metricsResponse = restTemplate.getForEntity("http://localhost:" + port + "/metrics", JsonNode.class);
+        assertThat(metricsResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        JsonNode rootObject = metricsResponse.getBody();
+        assertThat(rootObject.has("gauge.apis.crawled.success")).isTrue();
     }
 
     private ApiDefinition retrieveApiDefinition() {

--- a/storage/src/test/resources/application.yml
+++ b/storage/src/test/resources/application.yml
@@ -17,6 +17,7 @@ endpoints:
     enabled: true
   metrics:
     enabled: true
+    sensitive: false
 
 security:
   basic:

--- a/storage/src/test/resources/application.yml
+++ b/storage/src/test/resources/application.yml
@@ -24,6 +24,7 @@ security:
     enabled: false
 
 lifecycle-check.delay: 300000
+metrics-collecting.delay: 30000
 
 inactive.time: 600
 decommissioned.time: 3600


### PR DESCRIPTION
This PR adds:
- metrics endpoint to storage
- technical default metrics for zmon
- automatic metrics curation on an intervall
- metrics for number of APIs in different status and lifecycle states (which can be later used for data-based decision making)