### PR TITLE
Fix charset handling in crawler

### DIFF
--- a/crawler/src/main/java/org/zalando/apidiscovery/crawler/ApiDefinitionCrawlJob.java
+++ b/crawler/src/main/java/org/zalando/apidiscovery/crawler/ApiDefinitionCrawlJob.java
@@ -1,5 +1,10 @@
 package org.zalando.apidiscovery.crawler;
 
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -11,25 +16,20 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestOperations;
-import org.zalando.stups.clients.kio.ApplicationBase;
+import org.springframework.web.client.RestTemplate;
 import org.zalando.apidiscovery.crawler.storage.ApiDefinition;
 import org.zalando.apidiscovery.crawler.storage.ApiDiscoveryStorageClient;
-
-import java.io.IOException;
-import java.net.UnknownHostException;
-import java.util.Optional;
-import java.util.concurrent.Callable;
+import org.zalando.stups.clients.kio.ApplicationBase;
 
 class ApiDefinitionCrawlJob implements Callable<Void> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ApiDefinitionCrawlJob.class);
 
     private final ApiDiscoveryStorageClient storageClient;
-    private final RestOperations schemaClient;
+    private final RestTemplate schemaClient;
     private final ApplicationBase app;
 
-    ApiDefinitionCrawlJob(ApiDiscoveryStorageClient storageClient, RestOperations schemaClient, ApplicationBase app) {
+    ApiDefinitionCrawlJob(ApiDiscoveryStorageClient storageClient, RestTemplate schemaClient, ApplicationBase app) {
         this.storageClient = storageClient;
         this.schemaClient = schemaClient;
         this.app = app;

--- a/crawler/src/main/java/org/zalando/apidiscovery/crawler/ApiDiscoveryCrawler.java
+++ b/crawler/src/main/java/org/zalando/apidiscovery/crawler/ApiDiscoveryCrawler.java
@@ -1,17 +1,5 @@
 package org.zalando.apidiscovery.crawler;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
-import org.springframework.web.client.RestOperations;
-import org.zalando.apidiscovery.crawler.storage.ApiDiscoveryStorageClient;
-import org.zalando.stups.clients.kio.ApplicationBase;
-import org.zalando.stups.clients.kio.KioOperations;
-
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -20,6 +8,18 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+import org.zalando.apidiscovery.crawler.storage.ApiDiscoveryStorageClient;
+import org.zalando.stups.clients.kio.ApplicationBase;
+import org.zalando.stups.clients.kio.KioOperations;
+
 @Component
 public class ApiDiscoveryCrawler {
 
@@ -27,13 +27,13 @@ public class ApiDiscoveryCrawler {
 
     private final KioOperations kioClient;
     private final ApiDiscoveryStorageClient storageClient;
-    private final RestOperations schemaClient;
+    private final RestTemplate schemaClient;
     private final ExecutorService fixedPool;
 
     @Autowired
     public ApiDiscoveryCrawler(KioOperations kioClient,
                                ApiDiscoveryStorageClient storageClient,
-                               RestOperations schemaClient,
+                               RestTemplate schemaClient,
                                @Value("${crawler.jobs.pool}") int jobsPoolSize) {
         this.kioClient = kioClient;
         this.storageClient = storageClient;

--- a/crawler/src/main/java/org/zalando/apidiscovery/crawler/ClientsConfiguration.java
+++ b/crawler/src/main/java/org/zalando/apidiscovery/crawler/ClientsConfiguration.java
@@ -1,10 +1,14 @@
 package org.zalando.apidiscovery.crawler;
 
+import java.nio.charset.Charset;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestOperations;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+import org.zalando.apidiscovery.crawler.storage.ApiDiscoveryStorageClient;
 import org.zalando.stups.clients.kio.KioOperations;
 import org.zalando.stups.clients.kio.spring.RestTemplateKioOperations;
 import org.zalando.stups.oauth2.spring.client.StupsOAuth2RestTemplate;
@@ -12,7 +16,6 @@ import org.zalando.stups.oauth2.spring.client.StupsTokensAccessTokenProvider;
 import org.zalando.stups.spring.http.client.ClientHttpRequestFactorySelector;
 import org.zalando.stups.spring.http.client.TimeoutConfig;
 import org.zalando.stups.tokens.AccessTokens;
-import org.zalando.apidiscovery.crawler.storage.ApiDiscoveryStorageClient;
 
 @Configuration
 public class ClientsConfiguration {
@@ -40,11 +43,13 @@ public class ClientsConfiguration {
     }
 
     @Bean
-    public RestOperations oauth2Operations() {
-        return buildOAuth2RestTemplate("schema");
+    public RestTemplate oauth2Operations() {
+        RestTemplate restTemplate = buildOAuth2RestTemplate("schema");
+        restTemplate.getMessageConverters().add(0, new StringHttpMessageConverter(Charset.forName("UTF-8")));
+        return restTemplate;
     }
 
-    private RestOperations buildOAuth2RestTemplate(final String tokenName) {
+    private RestTemplate buildOAuth2RestTemplate(final String tokenName) {
         return new StupsOAuth2RestTemplate(new StupsTokensAccessTokenProvider(tokenName, accessTokens),
                 ClientHttpRequestFactorySelector.getRequestFactory(new TimeoutConfig.Builder()
                         .withReadTimeout(readTimeout)

--- a/crawler/src/test/java/org/zalando/apidiscovery/crawler/YamlToJsonConverterTest.java
+++ b/crawler/src/test/java/org/zalando/apidiscovery/crawler/YamlToJsonConverterTest.java
@@ -1,11 +1,11 @@
 package org.zalando.apidiscovery.crawler;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.Test;
-
-import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
This PR fixes charset handling in crawler: it currently breaks for some services as it does not support UTF-8 in yaml files.