### PR TITLE
#126 removing actuator

### DIFF
--- a/crawler/build.gradle
+++ b/crawler/build.gradle
@@ -36,7 +36,6 @@ repositories {
 
 dependencies {
     compile('org.springframework.boot:spring-boot-starter')
-    compile("org.springframework.boot:spring-boot-starter-actuator")
     compile('org.apache.httpcomponents:httpclient:4.5.3')
     compile('org.zalando.stups:stups-spring-oauth2-client:1.0.19')
     compile('org.zalando.stups:tokens:0.11.0-beta-2')


### PR DESCRIPTION
`org.springframework.boot:spring-boot-starter-actuator` requires `org.springframework.boot:spring-boot-starter-web`. We decided not to use Actuator and have another health check in place.